### PR TITLE
Decouple from DOM

### DIFF
--- a/src/ReasonReactContext.re
+++ b/src/ReasonReactContext.re
@@ -1,5 +1,18 @@
 module type Config = {type state; let name: string; let defaultValue: state;};
 
+/* This allows for children pass through without coupling to the DOM with ReasonReact.createDomElement */
+module RenderChildren = {
+  let passThrough: ReasonReact.reactClass = [%bs.raw
+    {| props => props.children |}
+  ];
+  let make = children =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass=passThrough,
+      ~props=Js.Obj.empty(),
+      children
+    );
+};
+
 module CreateContext = (C: Config) => {
   type action =
     | ChangeState(C.state);
@@ -28,7 +41,7 @@ module CreateContext = (C: Config) => {
         updateState(value);
         ReasonReact.NoUpdate;
       },
-      render: _self => ReasonReact.arrayToElement(children)
+      render: _self => <RenderChildren> ...children </RenderChildren>
     };
   };
   module Consumer = {

--- a/src/ReasonReactContext.re
+++ b/src/ReasonReactContext.re
@@ -19,7 +19,8 @@ module CreateContext = (C: Config) => {
     List.iter(f => f(newState), subscriptions^);
   };
   module Provider = {
-    let component = ReasonReact.statelessComponent(C.name ++ "ContextProvider");
+    let component =
+      ReasonReact.statelessComponent(C.name ++ "ContextProvider");
     let make = (~value=?, children) => {
       ...component,
       willReceiveProps: _self => updateState(value),
@@ -27,7 +28,7 @@ module CreateContext = (C: Config) => {
         updateState(value);
         ReasonReact.NoUpdate;
       },
-      render: _self => ReasonReact.createDomElement("div", ~props=Js.Obj.empty(), children)
+      render: _self => ReasonReact.arrayToElement(children)
     };
   };
   module Consumer = {
@@ -40,7 +41,10 @@ module CreateContext = (C: Config) => {
         | ChangeState(newState) => ReasonReact.Update(newState)
         },
       subscriptions: ({send}) => [
-        Sub(() => addSubscription(newState => send(ChangeState(newState))), unSub => unSub())
+        Sub(
+          () => addSubscription(newState => send(ChangeState(newState))),
+          unSub => unSub()
+        )
       ],
       render: ({state}) => children(state)
     };


### PR DESCRIPTION
This library looks great! There's only one thing preventing it from being used in bs-react-native and it's your use of creating a div with children in the Provider instead of just rendering the children, which ties it to the web.

The test you have in place checking for Provider's existence will likely break, and I think that's a good thing. The provider needs children in real React Context for it to pass its value to anything, so it'll simulate React's context a lot better. I suggest you check that it renders its children.

Thanks!